### PR TITLE
refactor: change the Post class to store the reference to User class

### DIFF
--- a/src/main/java/dev/emmanoel/ignitefeedbackend/application/post/create/CreatePost.java
+++ b/src/main/java/dev/emmanoel/ignitefeedbackend/application/post/create/CreatePost.java
@@ -27,7 +27,7 @@ public class CreatePost {
             .entrySet()
             .stream()
             .collect(Collectors.toMap(e -> ContentType.valueOf(e.getKey().toUpperCase()), Map.Entry::getValue));
-        var post = new Post(author, new Content(contents), input.publicationDate());
+        var post = new Post(author.getId(), new Content(contents), input.publicationDate());
         postRepo.save(post);
         return new CreatePostOutput(post.getId());
     }

--- a/src/main/java/dev/emmanoel/ignitefeedbackend/application/post/get/GetPost.java
+++ b/src/main/java/dev/emmanoel/ignitefeedbackend/application/post/get/GetPost.java
@@ -2,6 +2,8 @@ package dev.emmanoel.ignitefeedbackend.application.post.get;
 
 import dev.emmanoel.ignitefeedbackend.domain.post.PostNotFoundException;
 import dev.emmanoel.ignitefeedbackend.domain.post.PostRepository;
+import dev.emmanoel.ignitefeedbackend.domain.user.UserNotFoundException;
+import dev.emmanoel.ignitefeedbackend.domain.user.UserRepository;
 
 import java.util.Map;
 import java.util.UUID;
@@ -10,18 +12,21 @@ import java.util.stream.Collectors;
 public class GetPost {
 
     private final PostRepository postRepo;
+    private final UserRepository userRepo;
 
-    public GetPost(final PostRepository postRepository) {
+    public GetPost(final PostRepository postRepository, final UserRepository userRepository) {
         postRepo = postRepository;
+        userRepo = userRepository;
     }
 
-    public GetPostOutput execute(UUID id) {
+    public GetPostOutput execute(final UUID id) {
         var post = postRepo.findById(id).orElseThrow(PostNotFoundException::new);
+        var author = userRepo.findById(post.getAuthorId()).orElseThrow(UserNotFoundException::new);
         var content = post.getContent()
             .getContents()
             .entrySet()
             .stream()
             .collect(Collectors.toMap(e -> e.getKey().toString().toLowerCase(), Map.Entry::getValue));
-        return new GetPostOutput(AuthorOutput.of(post.getAuthor()), content, post.getPublicationDate());
+        return new GetPostOutput(AuthorOutput.of(author), content, post.getPublicationDate());
     }
 }

--- a/src/main/java/dev/emmanoel/ignitefeedbackend/application/post/getall/AuthorOutput.java
+++ b/src/main/java/dev/emmanoel/ignitefeedbackend/application/post/getall/AuthorOutput.java
@@ -1,4 +1,9 @@
 package dev.emmanoel.ignitefeedbackend.application.post.getall;
 
+import dev.emmanoel.ignitefeedbackend.domain.user.User;
+
 public record AuthorOutput(String name, String role) {
+    public static AuthorOutput createAuthorOutputOf(final User author) {
+        return new AuthorOutput(author.getName(), author.getRole());
+    }
 }

--- a/src/main/java/dev/emmanoel/ignitefeedbackend/application/post/getall/GetPosts.java
+++ b/src/main/java/dev/emmanoel/ignitefeedbackend/application/post/getall/GetPosts.java
@@ -1,27 +1,35 @@
 package dev.emmanoel.ignitefeedbackend.application.post.getall;
 
 import dev.emmanoel.ignitefeedbackend.domain.post.PostRepository;
+import dev.emmanoel.ignitefeedbackend.domain.user.UserNotFoundException;
+import dev.emmanoel.ignitefeedbackend.domain.user.UserRepository;
 
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static dev.emmanoel.ignitefeedbackend.application.post.getall.AuthorOutput.createAuthorOutputOf;
+import static dev.emmanoel.ignitefeedbackend.application.post.getall.GetPostsOutput.createGetPostsOutputWith;
+
 public class GetPosts {
     private final PostRepository postRepo;
+    private final UserRepository userRepo;
 
-    public GetPosts(PostRepository postRepository) {
+    public GetPosts(final PostRepository postRepository, final UserRepository userRepository) {
         postRepo = postRepository;
+        userRepo = userRepository;
     }
 
     public List<GetPostsOutput> execute() {
         return postRepo.findAll().stream().map(post -> {
-            var author = new AuthorOutput(post.getAuthor().getName(), post.getAuthor().getRole());
+            var author = userRepo.findById(post.getAuthorId()).orElseThrow(UserNotFoundException::new);
+            var authorOutput = createAuthorOutputOf(author);
             var content = post.getContent()
                 .getContents()
                 .entrySet()
                 .stream()
                 .collect(Collectors.toMap(e -> e.getKey().toString(), Map.Entry::getValue));
-            return new GetPostsOutput(author, content, post.getPublicationDate());
+            return createGetPostsOutputWith(authorOutput, content, post.getPublicationDate());
         }).toList();
     }
 }

--- a/src/main/java/dev/emmanoel/ignitefeedbackend/application/post/getall/GetPostsOutput.java
+++ b/src/main/java/dev/emmanoel/ignitefeedbackend/application/post/getall/GetPostsOutput.java
@@ -5,5 +5,8 @@ import java.util.List;
 import java.util.Map;
 
 public record GetPostsOutput(AuthorOutput author, Map<String, List<String>> content, LocalDateTime publicationDate) {
+    public static GetPostsOutput createGetPostsOutputWith(AuthorOutput author, Map<String, List<String>> content, LocalDateTime publicationDate) {
+        return new GetPostsOutput(author, content, publicationDate);
+    }
 }
 

--- a/src/main/java/dev/emmanoel/ignitefeedbackend/domain/post/Post.java
+++ b/src/main/java/dev/emmanoel/ignitefeedbackend/domain/post/Post.java
@@ -2,24 +2,24 @@ package dev.emmanoel.ignitefeedbackend.domain.post;
 
 import dev.emmanoel.ignitefeedbackend.domain.AbstractEntity;
 import dev.emmanoel.ignitefeedbackend.domain.IAggregateRoot;
-import dev.emmanoel.ignitefeedbackend.domain.user.User;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
+import java.util.UUID;
 
 public class Post extends AbstractEntity implements IAggregateRoot {
-    private final User author;
+    private final UUID authorId;
     private final Content content;
     private final LocalDateTime publicationDate;
 
-    public Post(final User author, final Content content, final LocalDateTime publicationDate) {
-        this.author = Objects.requireNonNull(author);
+    public Post(final UUID authorId, final Content content, final LocalDateTime publicationDate) {
+        this.authorId = Objects.requireNonNull(authorId);
         this.content = Objects.requireNonNull(content);
         this.publicationDate = Objects.requireNonNull(publicationDate);
     }
 
-    public User getAuthor() {
-        return author;
+    public UUID getAuthorId() {
+        return authorId;
     }
 
     public Content getContent() {

--- a/src/test/java/dev/emmanoel/ignitefeedbackend/application/post/GetPostTest.java
+++ b/src/test/java/dev/emmanoel/ignitefeedbackend/application/post/GetPostTest.java
@@ -5,6 +5,7 @@ import dev.emmanoel.ignitefeedbackend.domain.post.Content;
 import dev.emmanoel.ignitefeedbackend.domain.post.Post;
 import dev.emmanoel.ignitefeedbackend.domain.post.PostRepository;
 import dev.emmanoel.ignitefeedbackend.domain.user.User;
+import dev.emmanoel.ignitefeedbackend.domain.user.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,17 +25,21 @@ class GetPostTest {
     @Mock
     private PostRepository postRepo;
 
+    @Mock
+    private UserRepository userRepo;
+
     @Test
     @DisplayName("should return a post")
     void shouldReturnAPost() {
         var author = new User("Emmaneol", "CEO: @MendesAssessoria");
         var content = new Content();
         content.addParagraph("Olá pessoal, tudo joia?");
-        var post = new Post(author, content, LocalDateTime.now());
-        var sut = new GetPost(postRepo);
+        var post = new Post(author.getId(), content, LocalDateTime.now());
+        var sut = new GetPost(postRepo, userRepo);
         when(postRepo.findById(any())).thenReturn(Optional.of(post));
+        when(userRepo.findById(any())).thenReturn(Optional.of(author));
         var output = sut.execute(post.getId());
-        assertEquals(post.getAuthor().getId(), output.author().id());
+        assertEquals(post.getAuthorId(), output.author().id());
         assertEquals(post.getContent().getContents().size(), output.content().size());
         assertEquals(post.getPublicationDate(), output.publicationDate());
     }

--- a/src/test/java/dev/emmanoel/ignitefeedbackend/application/post/GetPostsTest.java
+++ b/src/test/java/dev/emmanoel/ignitefeedbackend/application/post/GetPostsTest.java
@@ -5,25 +5,38 @@ import dev.emmanoel.ignitefeedbackend.domain.post.Content;
 import dev.emmanoel.ignitefeedbackend.domain.post.Post;
 import dev.emmanoel.ignitefeedbackend.domain.post.PostRepository;
 import dev.emmanoel.ignitefeedbackend.domain.user.User;
+import dev.emmanoel.ignitefeedbackend.domain.user.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 class GetPostsTest {
+
+    @Mock
+    private PostRepository postRepo;
+
+    @Mock
+    private UserRepository userRepo;
 
     @Test
     @DisplayName("should return list of posts")
     void shouldReturnListOfPosts() {
-        var post = new Post(new User("Emmanoel", "CEO @MendesAssessoria"), new Content(), LocalDateTime.now());
-        var postRepo = mock(PostRepository.class);
+        var author = new User("Emmanoel", "CEO @MendesAssessoria");
+        var post = new Post(author.getId(), new Content(), LocalDateTime.now());
         when(postRepo.findAll()).thenReturn(List.of(post, post));
-        var sut = new GetPosts(postRepo);
+        when(userRepo.findById(any())).thenReturn(Optional.of(author));
+        var sut = new GetPosts(postRepo, userRepo);
         var posts = sut.execute();
         assertEquals(2, posts.size());
     }

--- a/src/test/java/dev/emmanoel/ignitefeedbackend/domain/post/PostTest.java
+++ b/src/test/java/dev/emmanoel/ignitefeedbackend/domain/post/PostTest.java
@@ -1,10 +1,10 @@
 package dev.emmanoel.ignitefeedbackend.domain.post;
 
-import dev.emmanoel.ignitefeedbackend.domain.user.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -21,16 +21,16 @@ class PostTest {
     @Test
     @DisplayName("should not create post without content")
     void shouldNotCreatePostWithoutContent() {
-        var author = new User("User", "CEO");
+        var authorId = UUID.randomUUID();
         var publicationDate = LocalDateTime.now();
-        assertThrows(NullPointerException.class, () -> new Post(author, null, publicationDate));
+        assertThrows(NullPointerException.class, () -> new Post(authorId, null, publicationDate));
     }
 
     @Test
     @DisplayName("should not create post without publication date")
     void shouldNotCreatePostWithoutPublicationDate() {
-        var author = new User("User", "CEO");
+        var authorId = UUID.randomUUID();
         var content = new Content();
-        assertThrows(NullPointerException.class, () -> new Post(author, content, null));
+        assertThrows(NullPointerException.class, () -> new Post(authorId, content, null));
     }
 }


### PR DESCRIPTION
To create a relationship between aggregates, we use an attribute that references the other aggregate instead of composing the object.